### PR TITLE
Stable v4.0 planck gpsfix novercheck

### DIFF
--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -445,6 +445,6 @@ QString QGCCorePlugin::stableVersionCheckFileUrl() const
     // Custom builds must override to turn on and provide their own location
     return QString();
 #else
-    return QString("https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGC.version.txt");
+    return QString();//"https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGC.version.txt");
 #endif
 }


### PR DESCRIPTION
[ACE-715](https://planckaero.atlassian.net/browse/ACE-715?atlOrigin=eyJpIjoiYTBkYzRiYzFhZWFjNDYzYmIxZTVjOWExODJmNTdkYjgiLCJwIjoiaiJ9)

Fix for using internal GPSs, which were not being utilized previously.

Also prevents new version checking.