### PR TITLE
Add support for compass priority

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -91,6 +91,7 @@ SetupPage {
                 case _calTypeCompass:
                     _orientationsDialogShowCompass = true
                     _orientationDialogHelp = orientationHelpCal
+                    _singleCompassSettingsComponentShowPriority = false
                     dialogTitle = qsTr("Calibrate Compass")
                     buttons |= StandardButton.Cancel
                     break
@@ -108,6 +109,28 @@ SetupPage {
                 }
 
                 mainWindow.showComponentDialog(orientationsDialogComponent, dialogTitle, mainWindow.showDialogDefaultWidth, buttons)
+            }
+
+            function compassLabel(index) {
+                var label = qsTr("Compass %1 ").arg(index+1)
+                var addOpenParan = true
+                var addComma = false
+                if (sensorParams.compassPrimaryFactAvailable) {
+                    label += sensorParams.rgCompassPrimary[index] ? qsTr("(primary") : qsTr("(secondary")
+                    addComma = true
+                    addOpenParan = false
+                }
+                if (sensorParams.rgCompassExternalParamAvailable[index]) {
+                    if (addOpenParan) {
+                        label += "("
+                    }
+                    if (addComma) {
+                        label += qsTr(", ")
+                    }
+                    label += sensorParams.rgCompassExternal[index] ? qsTr("external") : qsTr("internal")
+                }
+                label += ")"
+                return label
             }
 
             APMSensorParams {
@@ -142,6 +165,7 @@ SetupPage {
                         mainWindow.showComponentDialog(postCalibrationComponent, qsTr("Compass calibration complete"), mainWindow.showDialogDefaultWidth, StandardButton.Ok)
                         break
                     case APMSensorsComponentController.CalTypeOnboardCompass:
+                        _singleCompassSettingsComponentShowPriority = true
                         mainWindow.showComponentDialog(postOnboardCompassCalibrationComponent, qsTr("Calibration complete"), mainWindow.showDialogDefaultWidth, StandardButton.Ok)
                         break
                     }
@@ -189,6 +213,8 @@ SetupPage {
                     spacing:        Math.round(ScreenTools.defaultFontPixelHeight / 2)
                     visible:        sensorParams.rgCompassAvailable[index] && sensorParams.rgCompassUseFact[index].value
 
+                    property int _index: index
+
                     property real greenMaxThreshold:   8 * (sensorParams.rgCompassExternal[index] ? 1 : 2)
                     property real yellowMaxThreshold:  15 * (sensorParams.rgCompassExternal[index] ? 1 : 2)
                     property real fitnessRange:        25 * (sensorParams.rgCompassExternal[index] ? 1 : 2)
@@ -230,26 +256,13 @@ SetupPage {
                         }
                     }
 
-                    Column {
+                    Loader {
                         anchors.leftMargin: ScreenTools.defaultFontPixelWidth * 2
                         anchors.left:       parent.left
                         anchors.right:      parent.right
-                        spacing:            Math.round(ScreenTools.defaultFontPixelHeight / 4)
+                        sourceComponent:    singleCompassSettingsComponent
 
-                        QGCLabel {
-                            text: qsTr("Compass ") + (index+1) + " " +
-                                  (sensorParams.rgCompassPrimary[index] ? qsTr("(primary") : qsTr("(secondary")) +
-                                  (sensorParams.rgCompassExternalParamAvailable[index] ?
-                                       (sensorParams.rgCompassExternal[index] ? qsTr(", external") : qsTr(", internal" )) :
-                                       "") +
-                                  ")"
-                        }
-
-                        FactCheckBox {
-                            text:       qsTr("Use Compass")
-                            fact:       sensorParams.rgCompassUseFact[index]
-                            visible:    sensorParams.rgCompassUseParamAvailable[index] && !sensorParams.rgCompassPrimary[index]
-                        }
+                        property int index: _index
                     }
                 }
             }
@@ -314,11 +327,12 @@ SetupPage {
                                 controller.vehicle.rebootVehicle()
                                 hideDialog()
                             }
-                       }
+                        }
                     }
                 }
             }
 
+            property bool _singleCompassSettingsComponentShowPriority: true
             Component {
                 id: singleCompassSettingsComponent
 
@@ -327,12 +341,7 @@ SetupPage {
                     visible: sensorParams.rgCompassAvailable[index]
 
                     QGCLabel {
-                        text: qsTr("Compass ") + (index+1) + " " +
-                              (sensorParams.rgCompassPrimary[index] ? qsTr("(primary") :qsTr( "(secondary")) +
-                              (sensorParams.rgCompassExternalParamAvailable[index] ?
-                                   (sensorParams.rgCompassExternal[index] ? qsTr(", external") : qsTr(", internal") ) :
-                                   "") +
-                              ")"
+                        text: compassLabel(index)
                     }
 
                     Column {
@@ -340,10 +349,46 @@ SetupPage {
                         anchors.left:       parent.left
                         spacing:            Math.round(ScreenTools.defaultFontPixelHeight / 4)
 
-                        FactCheckBox {
-                            text:       qsTr("Use Compass")
-                            fact:       sensorParams.rgCompassUseFact[index]
-                            visible:    sensorParams.rgCompassUseParamAvailable[index] && !sensorParams.rgCompassPrimary[index]
+                        RowLayout {
+                            spacing: ScreenTools.defaultFontPixelWidth
+
+                            FactCheckBox {
+                                id:         useCompassCheckBox
+                                text:       qsTr("Use Compass")
+                                fact:       sensorParams.rgCompassUseFact[index]
+                                visible:    sensorParams.rgCompassUseParamAvailable[index] && !sensorParams.rgCompassPrimary[index]
+                            }
+
+                            QGCComboBox {
+                                model:      [ qsTr("Priority 1"), qsTr("Priority 2"), qsTr("Priority 3"), qsTr("Not Set") ]
+                                visible:    _singleCompassSettingsComponentShowPriority && sensorParams.compassPrioFactsAvailable && useCompassCheckBox.visible && useCompassCheckBox.checked
+
+                                property int _compassIndex: index
+
+                                function selectPriorityfromParams() {
+                                    if (visible) {
+                                        currentIndex = 3
+                                        var compassId = sensorParams.rgCompassId[_compassIndex].rawValue
+                                        for (var prioIndex=0; prioIndex<3; prioIndex++) {
+                                            if (compassId == sensorParams.rgCompassPrio[prioIndex].rawValue) {
+                                                currentIndex = prioIndex
+                                                break
+                                            }
+                                        }
+                                    }
+                                }
+
+                                Component.onCompleted: selectPriorityfromParams()
+
+                                onActivated: {
+                                    if (index == 3) {
+                                        // User cannot select Not Set
+                                        selectPriorityfromParams()
+                                    } else {
+                                        sensorParams.rgCompassPrio[index].rawValue = sensorParams.rgCompassId[_compassIndex].rawValue
+                                    }
+                                }
+                            }
                         }
 
                         Column {

--- a/src/FirmwarePlugin/APM/APMSensorParams.qml
+++ b/src/FirmwarePlugin/APM/APMSensorParams.qml
@@ -17,15 +17,23 @@ Item {
 
     property Fact _noFact: Fact { }
 
-    property Fact compassPrimaryFact:               factPanelController.getParameterFact(-1, "COMPASS_PRIMARY")
-    property bool compass1Primary:                  compassPrimaryFact.rawValue == 0
-    property bool compass2Primary:                  compassPrimaryFact.rawValue == 1
-    property bool compass3Primary:                  compassPrimaryFact.rawValue == 2
+    property bool compassPrimaryFactAvailable:      factPanelController.parameterExists(-1, "COMPASS_PRIMARY")
+    property Fact compassPrimaryFact:               compassPrimaryFactAvailable ? factPanelController.getParameterFact(-1, "COMPASS_PRIMARY") : _noFact
+    property bool compass1Primary:                  compassPrimaryFactAvailable ? compassPrimaryFact.rawValue == 0 : false
+    property bool compass2Primary:                  compassPrimaryFactAvailable ? compassPrimaryFact.rawValue == 1 : false
+    property bool compass3Primary:                  compassPrimaryFactAvailable ? compassPrimaryFact.rawValue == 2 : false
     property var  rgCompassPrimary:                 [ compass1Primary, compass2Primary, compass3Primary ]
 
     property Fact compass1Id:                       factPanelController.getParameterFact(-1, "COMPASS_DEV_ID")
     property Fact compass2Id:                       factPanelController.getParameterFact(-1, "COMPASS_DEV_ID2")
     property Fact compass3Id:                       factPanelController.getParameterFact(-1, "COMPASS_DEV_ID3")
+    property var  rgCompassId:                      [ compass1Id, compass2Id, compass3Id ]
+
+    property bool compassPrioFactsAvailable:        factPanelController.parameterExists(-1, "COMPASS_PRIO1_ID")
+    property Fact compassPrio1Fact:                 compassPrioFactsAvailable ? factPanelController.getParameterFact(-1, "COMPASS_PRIO1_ID") : _noFact
+    property Fact compassPrio2Fact:                 compassPrioFactsAvailable ? factPanelController.getParameterFact(-1, "COMPASS_PRIO2_ID") : _noFact
+    property Fact compassPrio3Fact:                 compassPrioFactsAvailable ? factPanelController.getParameterFact(-1, "COMPASS_PRIO3_ID") : _noFact
+    property var  rgCompassPrio:                    [ compassPrio1Fact, compassPrio2Fact, compassPrio3Fact ]
 
     property bool compass1Available:                compass1Id.value > 0
     property bool compass2Available:                compass2Id.value > 0


### PR DESCRIPTION
[ACE-815](https://planckaero.atlassian.net/browse/ACE-815?atlOrigin=eyJpIjoiM2NmMWMwMTQyNGE5NDYwYTg4M2Y0ZDBhOTdkNTU0ZTEiLCJwIjoiaiJ9)

Addresses issue with APM v4.0.4 which removes the `COMPASS_PRIMARY` parameter.  This diff is a cherry-pick of https://github.com/mavlink/qgroundcontrol/commit/b1860d284ab709d7edfb4f6fc955f49a962c64fd#diff-bb218e3c78b2d638d2fa7ca26994c608e8b66049c00dd44c3fd113cc30f274cc.