### PR TITLE
[AA-233] ACE/Anafi Flight Mode

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -96,6 +96,8 @@ linux {
         QMAKE_CXXFLAGS += -fvisibility=hidden
         #-- Disable annoying warnings comming from mavlink.h
         QMAKE_CXXFLAGS += -Wno-address-of-packed-member
+        QMAKE_LFLAGS += -L/Library/Frameworks/GStreamer.framework/Versions/Current/lib
+
     } else {
         error("Unsupported Mac toolchain, only 64-bit LLVM+clang is supported")
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1735,8 +1735,10 @@ void Vehicle::_handleACEHeartbeat(mavlink_message_t& message)
    switch(newACECustomModeIdx) {
        case 0: newACEMode = "ACE:Idle";    break;
        case 1: newACEMode = "ACE:Takeoff"; break;
-       case 2: newACEMode = "ACE:RTB";     break;
-       case 3: newACEMode = "ACE:Land";    break;
+       case 2: newACEMode = "ACE:Track";   break;
+       case 3: newACEMode = "ACE:RTB";     break;
+       case 4: newACEMode = "ACE:Land";    break;
+       case 5: newACEMode = "ACE:Wingman"; break;
        default: newACEMode = QString("ACE: ") + QString::number(newACECustomModeIdx); break;
    }
 
@@ -1753,7 +1755,7 @@ void Vehicle::_handleACEHeartbeat(mavlink_message_t& message)
 void Vehicle::_handleHeartbeat(mavlink_message_t& message)
 {
     //Check for an ACE message
-    if(message.compid == PLANCK_CTRL_COMP_ID) {
+    if(message.compid == 41) { //Anafi ACE supervisor
         _handleACEHeartbeat(message);
         return;
     }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1296,6 +1296,7 @@ private:
     void _handlePing                    (LinkInterface* link, mavlink_message_t& message);
     void _handleHomePosition            (mavlink_message_t& message);
     void _handleHeartbeat               (mavlink_message_t& message);
+    void _handleACEHeartbeat            (mavlink_message_t& message);
     void _handleRadioStatus             (mavlink_message_t& message);
     void _handleRCChannels              (mavlink_message_t& message);
     void _handleRCChannelsRaw           (mavlink_message_t& message);
@@ -1631,4 +1632,6 @@ private:
     static const char* _joystickModeSettingsKey;
     static const char* _joystickEnabledSettingsKey;
 
+    //ACE mode
+    QString _aceMode;
 };

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -353,7 +353,7 @@ void MockLink::_sendHeartBeat(void)
     count = 0;
 
     mavlink_msg_heartbeat_pack_chan(_vehicleSystemId,
-                                    PLANCK_CTRL_COMP_ID,
+                                    41, //Anafi ACE supervisor
                                     _mavlinkChannel,
                                     &msg,
                                     MAV_TYPE_ONBOARD_CONTROLLER,        // MAV_TYPE

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -367,10 +367,10 @@ void MockLink::_sendHeartBeat(void)
     copiloting_custom.len = mavlink_msg_to_send_buffer(copiloting_custom.data, &msg);
     mavlink_message_t copiloting_custom_msg;
     mavlink_msg_copiloting_custom_encode_chan(_vehicleSystemId,
-                                            _vehicleComponentId,
-                                            _mavlinkChannel,
-                                            &copiloting_custom_msg,
-                                            &copiloting_custom);
+                                              _vehicleComponentId,
+                                              _mavlinkChannel,
+                                              &copiloting_custom_msg,
+                                              &copiloting_custom);
     respondWithMavlinkMessage(copiloting_custom_msg);
 }
 

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -345,6 +345,33 @@ void MockLink::_sendHeartBeat(void)
                                     _mavState);          // MAV_STATE
 
     respondWithMavlinkMessage(msg);
+
+    static uint8_t idx = 0;
+    if(idx > 3) idx = 0;
+    static uint8_t count = 0;
+    if(++count < 9) return;
+    count = 0;
+
+    mavlink_msg_heartbeat_pack_chan(_vehicleSystemId,
+                                    PLANCK_CTRL_COMP_ID,
+                                    _mavlinkChannel,
+                                    &msg,
+                                    MAV_TYPE_ONBOARD_CONTROLLER,        // MAV_TYPE
+                                    MAV_AUTOPILOT_INVALID,      // MAV_AUTOPILOT
+                                    0,        // MAV_MODE
+                                    idx++,      // custom mode
+                                    0);          // MAV_STATE
+    qDebug() << "index: " << idx;
+
+    mavlink_copiloting_custom_t copiloting_custom;
+    copiloting_custom.len = mavlink_msg_to_send_buffer(copiloting_custom.data, &msg);
+    mavlink_message_t copiloting_custom_msg;
+    mavlink_msg_copiloting_custom_encode_chan(_vehicleSystemId,
+                                            _vehicleComponentId,
+                                            _mavlinkChannel,
+                                            &copiloting_custom_msg,
+                                            &copiloting_custom);
+    respondWithMavlinkMessage(copiloting_custom_msg);
 }
 
 void MockLink::_sendHighLatency2(void)


### PR DESCRIPTION
[AA-233]

This PR modifies QGC to display the ACE mode when PX4 (Anafi) is in "Offboard" mode. No ACE modes are selectable from the dropdown; this is for display only.

[AA-233]: https://planckaero.atlassian.net/browse/AA-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ