### PR TITLE
[AA-498] Use ANAFI_RTB_ALT for return altitude

### DIFF
--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -443,7 +443,7 @@ SetupPage {
                                 Layout.fillWidth:       true
                             }
                             FactTextField {
-                                fact:                   controller.getParameterFact(-1, "RTL_RETURN_ALT")
+                                fact:                   controller.getParameterFact(90, "ANAFI_RTB_ALT")
                                 Layout.minimumWidth:    _editFieldWidth
                                 Layout.fillWidth:       true
                             }


### PR DESCRIPTION
[AA-498]

Simple change which uses the ACE parameter `ANAFI_RTB_ALT` for the return altitude in the safety settings page.

Tested on the bench by verifying that the parameter changes when changing the value from the safety settings page.

https://user-images.githubusercontent.com/5853291/155430883-fba688ac-3b5d-45af-89e7-1a9ca8768cae.mov

.

[AA-498]: https://planckaero.atlassian.net/browse/AA-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ