### PR TITLE
[AA-519] Option to zero joystick throttle when not flying

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -31,6 +31,7 @@ const char* Joystick::_exponentialSettingsKey =         "Exponential";
 const char* Joystick::_accumulatorSettingsKey =         "Accumulator";
 const char* Joystick::_deadbandSettingsKey =            "Deadband";
 const char* Joystick::_circleCorrectionSettingsKey =    "Circle_Correction";
+const char* Joystick::_zeroThrottleNotFlyingSettingsKey =    "Zero_Throttle_Not_Flying";
 const char* Joystick::_axisFrequencySettingsKey =       "AxisFrequency";
 const char* Joystick::_buttonFrequencySettingsKey =     "ButtonFrequency";
 const char* Joystick::_txModeSettingsKey =              nullptr;
@@ -167,6 +168,7 @@ void Joystick::_setDefaultCalibration(void) {
     _throttleMode   = ThrottleModeDownZero;
     _calibrated     = true;
     _circleCorrection = false;
+    _zeroThrottleNotFlying = false;
 
     _saveSettings();
 }
@@ -228,6 +230,7 @@ void Joystick::_loadSettings()
     _axisFrequency  = settings.value(_axisFrequencySettingsKey, 25.0f).toFloat();
     _buttonFrequency= settings.value(_buttonFrequencySettingsKey, 5.0f).toFloat();
     _circleCorrection = settings.value(_circleCorrectionSettingsKey, false).toBool();
+    _zeroThrottleNotFlying = settings.value(_zeroThrottleNotFlyingSettingsKey, false).toBool();
     _gimbalEnabled  = settings.value(_gimbalSettingsKey, false).toBool();
 
     _throttleMode   = static_cast<ThrottleMode_t>(settings.value(_throttleModeSettingsKey, ThrottleModeDownZero).toInt(&convertOk));
@@ -334,6 +337,7 @@ void Joystick::_saveSettings()
     settings.setValue(_throttleModeSettingsKey,     _throttleMode);
     settings.setValue(_gimbalSettingsKey,           _gimbalEnabled);
     settings.setValue(_circleCorrectionSettingsKey, _circleCorrection);
+    settings.setValue(_zeroThrottleNotFlyingSettingsKey, _zeroThrottleNotFlying);
 
     qCDebug(JoystickLog) << "_saveSettings calibrated:throttlemode:deadband:txmode" << _calibrated << _throttleMode << _deadband << _circleCorrection << _transmitterMode;
 
@@ -631,6 +635,12 @@ void Joystick::_handleAxis()
             } else {
                 throttle = (throttle + 1.0f) / 2.0f;
             }
+            if(_zeroThrottleNotFlying) {
+                //if the aircraft is disarmed or not flying, send zero throttle
+                if(!_activeVehicle->flying() || !_activeVehicle->armed()) {
+                    throttle = 0;
+                }
+            }
             qCDebug(JoystickValuesLog) << "name:roll:pitch:yaw:throttle:gimbalPitch:gimbalYaw" << name() << roll << -pitch << yaw << throttle << gimbalPitch << gimbalYaw;
             // NOTE: The buttonPressedBits going to MANUAL_CONTROL are currently used by ArduSub (and it only handles 16 bits)
             // Set up button bitmap
@@ -924,6 +934,18 @@ void Joystick::setCircleCorrection(bool circleCorrection)
     _circleCorrection = circleCorrection;
     _saveSettings();
     emit circleCorrectionChanged(_circleCorrection);
+}
+
+bool Joystick::zeroThrottleNotFlying()
+{
+    return _zeroThrottleNotFlying;
+}
+
+void Joystick::setZeroThrottleNotFlying(bool zeroThrottleNotFlying)
+{
+    _zeroThrottleNotFlying = zeroThrottleNotFlying;
+    _saveSettings();
+    emit zeroThrottleNotFlyingChanged(_zeroThrottleNotFlying);
 }
 
 void Joystick::setGimbalEnabled(bool set)

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -168,7 +168,7 @@ void Joystick::_setDefaultCalibration(void) {
     _throttleMode   = ThrottleModeDownZero;
     _calibrated     = true;
     _circleCorrection = false;
-    _zeroThrottleNotFlying = false;
+    _zeroThrottleNotFlying = true;
 
     _saveSettings();
 }
@@ -230,7 +230,7 @@ void Joystick::_loadSettings()
     _axisFrequency  = settings.value(_axisFrequencySettingsKey, 25.0f).toFloat();
     _buttonFrequency= settings.value(_buttonFrequencySettingsKey, 5.0f).toFloat();
     _circleCorrection = settings.value(_circleCorrectionSettingsKey, false).toBool();
-    _zeroThrottleNotFlying = settings.value(_zeroThrottleNotFlyingSettingsKey, false).toBool();
+    _zeroThrottleNotFlying = settings.value(_zeroThrottleNotFlyingSettingsKey, true).toBool();
     _gimbalEnabled  = settings.value(_gimbalSettingsKey, false).toBool();
 
     _throttleMode   = static_cast<ThrottleMode_t>(settings.value(_throttleModeSettingsKey, ThrottleModeDownZero).toInt(&convertOk));

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -107,6 +107,7 @@ public:
     Q_PROPERTY(float    exponential             READ exponential            WRITE setExponential        NOTIFY exponentialChanged)
     Q_PROPERTY(bool     accumulator             READ accumulator            WRITE setAccumulator        NOTIFY accumulatorChanged)
     Q_PROPERTY(bool     circleCorrection        READ circleCorrection       WRITE setCircleCorrection   NOTIFY circleCorrectionChanged)
+    Q_PROPERTY(bool     zeroThrottleNotFlying   READ zeroThrottleNotFlying  WRITE setZeroThrottleNotFlying NOTIFY zeroThrottleNotFlying)
 
     Q_INVOKABLE void    setButtonRepeat     (int button, bool repeat);
     Q_INVOKABLE bool    getButtonRepeat     (int button);
@@ -164,6 +165,9 @@ public:
     bool  circleCorrection  ();
     void  setCircleCorrection(bool circleCorrection);
 
+    bool zeroThrottleNotFlying ();
+    void setZeroThrottleNotFlying (bool zeroThrottleNotFlying);
+
     void  setTXMode         (int mode);
     int   getTXMode         () { return _transmitterMode; }
 
@@ -193,6 +197,7 @@ signals:
     void accumulatorChanged         (bool accumulator);
     void enabledChanged             (bool enabled);
     void circleCorrectionChanged    (bool circleCorrection);
+    void zeroThrottleNotFlyingChanged (bool zeroThrottleNotFlying);
 
     /// Signal containing new joystick information
     ///     @param roll:            Range is -1:1, negative meaning roll left, positive meaning roll right
@@ -284,6 +289,7 @@ protected:
     bool    _accumulator            = false;
     bool    _deadband               = false;
     bool    _circleCorrection       = true;
+    bool    _zeroThrottleNotFlying  = false;
     float   _axisFrequency          = 25.0f;
     float   _buttonFrequency        = 5.0f;
     Vehicle* _activeVehicle         = nullptr;
@@ -321,6 +327,7 @@ private:
     static const char* _accumulatorSettingsKey;
     static const char* _deadbandSettingsKey;
     static const char* _circleCorrectionSettingsKey;
+    static const char* _zeroThrottleNotFlyingSettingsKey;
     static const char* _axisFrequencySettingsKey;
     static const char* _buttonFrequencySettingsKey;
     static const char* _txModeSettingsKey;

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -289,7 +289,7 @@ protected:
     bool    _accumulator            = false;
     bool    _deadband               = false;
     bool    _circleCorrection       = true;
-    bool    _zeroThrottleNotFlying  = false;
+    bool    _zeroThrottleNotFlying  = true;
     float   _axisFrequency          = 25.0f;
     float   _buttonFrequency        = 5.0f;
     Vehicle* _activeVehicle         = nullptr;

--- a/src/VehicleSetup/JoystickConfigAdvanced.qml
+++ b/src/VehicleSetup/JoystickConfigAdvanced.qml
@@ -100,7 +100,7 @@ Item {
             Component.onCompleted: {
                 checked = _activeJoystick.zeroThrottleNotFlying
             }
-            onClicked: {
+            onCheckedChanged: {
                 _activeJoystick.zeroThrottleNotFlying = checked
             }
         }

--- a/src/VehicleSetup/JoystickConfigAdvanced.qml
+++ b/src/VehicleSetup/JoystickConfigAdvanced.qml
@@ -96,7 +96,6 @@ Item {
         }
         QGCCheckBox {
             id:         zeroThrottleNotFlying
-            checked:    activeVehicle.joystickMode !== 0
             Component.onCompleted: {
                 checked = _activeJoystick.zeroThrottleNotFlying
             }

--- a/src/VehicleSetup/JoystickConfigAdvanced.qml
+++ b/src/VehicleSetup/JoystickConfigAdvanced.qml
@@ -88,6 +88,23 @@ Item {
             }
         }
         //-----------------------------------------------------------------
+        //-- Zero throttle while not flying
+        QGCLabel {
+            text:               qsTr("Zero throttle while aircraft not flying")
+            Layout.alignment:   Qt.AlignVCenter
+            Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 36
+        }
+        QGCCheckBox {
+            id:         zeroThrottleNotFlying
+            checked:    activeVehicle.joystickMode !== 0
+            Component.onCompleted: {
+                checked = _activeJoystick.zeroThrottleNotFlying
+            }
+            onClicked: {
+                _activeJoystick.zeroThrottleNotFlying = checked
+            }
+        }
+        //-----------------------------------------------------------------
         //-- Enable Advanced Mode
         QGCLabel {
             text:               qsTr("Enable further advanced settings (careful!)")


### PR DESCRIPTION
[AA-519]

Adds an option to zero out Joystick throttle values before they're emitted to the aircraf when the aircraft is disarmed or not flying.

[AA-519]: https://planckaero.atlassian.net/browse/AA-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ