### PR TITLE
[AA-544] - adding MODE_PLANCKREPOSITION && unlock camera in MODE_PLANCKTRACK

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1981,15 +1981,16 @@ QGCCameraControl::_handleHeartbeat (mavlink_message_t& message)
     AnafiMode custom_mode = static_cast<AnafiMode>(mavlink_msg_heartbeat_get_custom_mode(&message));
     switch(custom_mode) {
     case MODE_PLANCKTAKEOFF:
-    case MODE_PLANCKTRACK:
     case MODE_PLANCKRTB:
     case MODE_PLANCKLAND:
+    case MODE_PLANCKREPOSITION:
         if(!_locked) {
             qCDebug(CameraControlLog) << "Received ANAFI custom_mode (" << custom_mode << "). Locking camera.";
             _locked = true;
             emit lockedChanged();
         }
         break;
+    case MODE_PLANCKTRACK:
     case MODE_PLANCKIDLE:
     case MODE_PLANCKWINGMAN:
         if(_locked) {

--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -146,6 +146,7 @@ public:
         MODE_PLANCKRTB,
         MODE_PLANCKLAND,
         MODE_PLANCKWINGMAN,
+        MODE_PLANCKREPOSITION
     };
 
     Q_ENUM(CameraMode)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1733,12 +1733,13 @@ void Vehicle::_handleACEHeartbeat(mavlink_message_t& message)
    int newACECustomModeIdx = (int)mavlink_msg_heartbeat_get_custom_mode(&message);
    QString newACEMode;
    switch(newACECustomModeIdx) {
-       case 0: newACEMode = "ACE:Idle";    break;
-       case 1: newACEMode = "ACE:Takeoff"; break;
-       case 2: newACEMode = "ACE:Track";   break;
-       case 3: newACEMode = "ACE:RTB";     break;
-       case 4: newACEMode = "ACE:Land";    break;
-       case 5: newACEMode = "ACE:Wingman"; break;
+       case 0: newACEMode = "ACE:Idle";       break;
+       case 1: newACEMode = "ACE:Takeoff";    break;
+       case 2: newACEMode = "ACE:Track";      break;
+       case 3: newACEMode = "ACE:RTB";        break;
+       case 4: newACEMode = "ACE:Land";       break;
+       case 5: newACEMode = "ACE:Wingman";    break;
+       case 6: newACEMode = "ACE:Reposition"; break;
        default: newACEMode = QString("ACE: ") + QString::number(newACECustomModeIdx); break;
    }
 

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -32,6 +32,13 @@ Row {
         }
     }
 
+    Connections {
+        target: QGroundControl.multiVehicleManager
+        onActiveVehicleChanged: {
+            indicatorRepeater.model = activeVehicle ? activeVehicle.toolBarIndicators : []
+        }
+    }
+
     Repeater {
         id:    indicatorRepeater
         model: activeVehicle ? activeVehicle.toolBarIndicators : []


### PR DESCRIPTION
[AA-544](https://planckaero.atlassian.net/browse/AA-544)

Changes:
- adding `MODE_PLANCKREPOSITION` (camera locked)
- unlock camera in MODE_PLANCKTRACK