### PR TITLE
[AA-554] - only reset the model from advanced UI if vehicle is active

### DIFF
--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -28,7 +28,8 @@ Row {
     Connections {
         target: QGroundControl.corePlugin
         onShowAdvancedUIChanged: {
-            indicatorRepeater.model = activeVehicle ? activeVehicle.toolBarIndicators : []
+            if (activeVehicle)
+                indicatorRepeater.model = activeVehicle.toolBarIndicators;
         }
     }
 

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -28,8 +28,14 @@ Row {
     Connections {
         target: QGroundControl.corePlugin
         onShowAdvancedUIChanged: {
-            if (activeVehicle)
-                indicatorRepeater.model = activeVehicle.toolBarIndicators;
+            indicatorRepeater.model = activeVehicle ? activeVehicle.toolBarIndicators : []
+        }
+    }
+
+    Connections {
+        target: QGroundControl.multiVehicleManager
+        onActiveVehicleChanged: {
+            indicatorRepeater.model = activeVehicle ? activeVehicle.toolBarIndicators : []
         }
     }
 


### PR DESCRIPTION
[AA-554](https://planckaero.atlassian.net/browse/AA-554)

Only reset model if vehicle is active to avoid case where:
- model are reset to `[]` because no vehicle yet from UI `onShowAdvancedUIChanged`
- connection happen after, but then model is still set to `[]` so the toolbar is not populated

@almatthew my knowledge of qml is limited though, so is that the right way ?