### PR TITLE
[MQ-7] V4.2.0 malloy payloaddrop

### DIFF
--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -18,7 +18,7 @@
         <file alias="counter-clockwise-arrow.svg">resources/counter-clockwise-arrow.svg</file>
         <file alias="chevron-down.svg">resources/chevron-down.svg</file>
         <file alias="chevron-up.svg">resources/chevron-up.svg</file>
-		<file alias="DropArrow.svg">resources/DropArrow.svg</file>
+        <file alias="DropArrow.svg">resources/DropArrow.svg</file>
         <file alias="gear-black.svg">resources/gear-black.svg</file>
         <file alias="gear-white.svg">resources/gear-white.svg</file>
         <file alias="helicoptericon.svg">resources/helicoptericon.svg</file>
@@ -37,7 +37,7 @@
         <file alias="Play">resources/Play.svg</file>
         <file alias="PowerButton">resources/PowerButton.svg</file>
         <file alias="QGCLogoBlack">resources/QGCLogoBlack.svg</file>
-		<file alias="QGCLogoFull">resources/QGCLogoFull.svg</file>
+        <file alias="QGCLogoFull">resources/QGCLogoFull.svg</file>
         <file alias="QGCLogoWhite">resources/QGCLogoWhite.svg</file>
         <file alias="QGCLogoArrow">resources/QGCLogoArrow.svg</file>
         <file alias="QGroundControlConnect">resources/QGroundControlConnect.svg</file>
@@ -45,6 +45,7 @@
         <file alias="SplashScreen">resources/SplashScreen.png</file>
         <file alias="Stop">resources/Stop.svg</file>
         <file alias="takeoff.svg">resources/takeoff.svg</file>
+        <file alias="payload-drop.svg">resources/payload-drop.svg</file>
         <file alias="TrashDelete.svg">resources/TrashDelete.svg</file>
         <file alias="waves.svg">resources/waves.svg</file>
         <file alias="wind-guru.svg">resources/wind-guru.svg</file>

--- a/resources/payload-drop.svg
+++ b/resources/payload-drop.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 72 72"
+   style="enable-background:new 0 0 72 72;"
+   xml:space="preserve"
+   sodipodi:docname="payload-drop.svg"
+   inkscape:version="1.1.2 (b8e25be8, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs86" /><sodipodi:namedview
+   id="namedview84"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="8.6944444"
+   inkscape:cx="36"
+   inkscape:cy="35.942492"
+   inkscape:window-width="2560"
+   inkscape:window-height="1387"
+   inkscape:window-x="0"
+   inkscape:window-y="25"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style69">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:3;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:8;stroke-miterlimit:10;}
+	.st2{fill:#FFFFFF;}
+</style>
+<path
+   class="st0"
+   d="m 17.756,60.301 c -3.345,0 -6.056,-1.958 -6.056,-4.374 V 29.574 c 0,-2.416 2.711,-4.374 6.056,-4.374 h 36.488 c 3.345,0 6.056,1.958 6.056,4.374 v 26.353 c 0,2.416 -2.711,4.374 -6.056,4.374"
+   id="path71" />
+<g
+   id="g81"
+   transform="rotate(180,36,34.003501)">
+	<g
+   id="g79">
+		<line
+   class="st1"
+   x1="36"
+   y1="56.546001"
+   x2="36"
+   y2="31.554001"
+   id="line73" />
+		<g
+   id="g77">
+			<polygon
+   class="st2"
+   points="22.038,35.639 49.962,35.639 36,11.461 "
+   id="polygon75" />
+		</g>
+	</g>
+</g>
+</svg>

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -403,6 +403,16 @@ VisualMissionItem* MissionController::insertLandItem(QGeoCoordinate coordinate, 
     }
 }
 
+VisualMissionItem* MissionController::insertPayloadDropItems(int visualItemIndex, bool makeCurrentItem) {
+    SimpleMissionItem* release = qobject_cast<SimpleMissionItem*>(_insertSimpleMissionItemWorker(QGeoCoordinate(), MAV_CMD_DO_GRIPPER, visualItemIndex++, makeCurrentItem));
+    release->missionItem().setParam2(0);
+    SimpleMissionItem* delay = qobject_cast<SimpleMissionItem*>(_insertSimpleMissionItemWorker(QGeoCoordinate(), MAV_CMD_NAV_DELAY, visualItemIndex++, makeCurrentItem));
+    delay->missionItem().setParam1(1);
+    SimpleMissionItem* grab = qobject_cast<SimpleMissionItem*>(_insertSimpleMissionItemWorker(QGeoCoordinate(), MAV_CMD_DO_GRIPPER, visualItemIndex, makeCurrentItem));
+    grab->missionItem().setParam2(1);
+    return grab;
+}
+
 VisualMissionItem* MissionController::insertROIMissionItem(QGeoCoordinate coordinate, int visualItemIndex, bool makeCurrentItem)
 {
     SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(_insertSimpleMissionItemWorker(coordinate, MAV_CMD_DO_SET_ROI_LOCATION, visualItemIndex, makeCurrentItem));

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -135,6 +135,12 @@ public:
     /// @return Newly created item
     Q_INVOKABLE VisualMissionItem* insertLandItem(QGeoCoordinate coordinate, int visualItemIndex, bool makeCurrentItem = false);
 
+    /// Add payload drop items the list
+    ///     @param visualItemIndex: index to insert at, -1 for end of list
+    ///     @param makeCurrentItem: true: Make this item the current item
+    /// @return Newly created item
+    Q_INVOKABLE VisualMissionItem* insertPayloadDropItems(int visualItemIndex, bool makeCurrentItem = false);
+
     /// Add a new ROI mission item to the list
     ///     @param coordinate: Coordinate for item
     ///     @param visualItemIndex: index to insert at, -1 for end of list

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -341,6 +341,10 @@ Item {
         _missionController.insertLandItem(mapCenter(), nextIndex, true /* makeCurrentItem */)
     }
 
+    function insertPayloadDropAfterCurrent() {
+        var nextIndex = _missionController.currentPlanViewVIIndex + 1
+        _missionController.insertPayloadDropItems(nextIndex, true /* makeCurrentItem */)
+    }
 
     function selectNextNotReady() {
         var foundCurrent = false
@@ -697,11 +701,11 @@ Item {
                     ToolStripAction {
                         text: "Drop"
                         iconSource: "/res/payload-drop.svg"
-                        enabled: true
+                        enabled:            !_missionController.onlyInsertTakeoffValid
                         visible: toolStrip._isMissionLayer
                         onTriggered: {
                             toolStrip.allAddClickBoolsOff()
-                            insertLandItemAfterCurrent()
+                            insertPayloadDropAfterCurrent()
                         }
                     },
                     ToolStripAction {

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -695,6 +695,16 @@ Item {
                         }
                     },
                     ToolStripAction {
+                        text: "Drop"
+                        iconSource: "/res/payload-drop.svg"
+                        enabled: true
+                        visible: toolStrip._isMissionLayer
+                        onTriggered: {
+                            toolStrip.allAddClickBoolsOff()
+                            insertLandItemAfterCurrent()
+                        }
+                    },
+                    ToolStripAction {
                         text:       _planMasterController.controllerVehicle.multiRotor ? qsTr("Return") : qsTr("Land")
                         iconSource: "/res/rtl.svg"
                         enabled:    _missionController.isInsertLandValid


### PR DESCRIPTION
[MQ-7]

Add an action to auto-populate mission items for a "payload drop", which a sequence of Gripper-release, delay, gripper-grab.

A possible follow-on would be to convert this into a `ComplexMissionItem` to merge the 3 waypoints into one, but I believe this is a good starting point.


https://user-images.githubusercontent.com/5853291/167958733-8c2c6feb-96d2-49df-bd91-d038c33d2562.mov



[MQ-7]: https://planckaero.atlassian.net/browse/MQ-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ