### PR TITLE
[MQ-18] V4.2.0 malloy wait to takeoff

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -891,13 +891,18 @@ bool APMFirmwarePlugin::_guidedModeTakeoff(Vehicle* vehicle, double altitudeRel)
         takeoffAltRel = altitudeRel;
     }
 
-    if (!_setFlightModeAndValidate(vehicle, "Guided")) {
-        qgcApp()->showAppMessage(tr("Unable to takeoff: Vehicle failed to change to Guided mode."));
+    if (!_setFlightModeAndValidate(vehicle, "Stabilize")) {
+        qgcApp()->showAppMessage(tr("Unable to takeoff: Vehicle failed to change to Stabilize mode."));
         return false;
     }
 
     if (!_armVehicleAndValidate(vehicle)) {
         qgcApp()->showAppMessage(tr("Unable to takeoff: Vehicle failed to arm."));
+        return false;
+    }
+
+    if (!_setFlightModeAndValidate(vehicle, "Guided")) {
+        qgcApp()->showAppMessage(tr("Unable to takeoff: Vehicle failed to change to Guided mode."));
         return false;
     }
 
@@ -928,8 +933,8 @@ void APMFirmwarePlugin::startMission(Vehicle* vehicle)
 
     if (!vehicle->armed()) {
         // First switch to flight mode we can arm from
-        if (!_setFlightModeAndValidate(vehicle, "Guided")) {
-            qgcApp()->showAppMessage(tr("Unable to start mission: Vehicle failed to change to Guided mode."));
+        if (!_setFlightModeAndValidate(vehicle, "Stabilize")) {
+            qgcApp()->showAppMessage(tr("Unable to start mission: Vehicle failed to change to Stabilize mode."));
             return;
         }
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -901,6 +901,12 @@ bool APMFirmwarePlugin::_guidedModeTakeoff(Vehicle* vehicle, double altitudeRel)
         return false;
     }
 
+    // Wait 300 msecs before sending a takeoff command
+    for (int i=0; i<3; i++) {
+        QGC::SLEEP::msleep(100);
+        qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+    }
+
     vehicle->sendMavCommand(vehicle->defaultComponentId(),
                             MAV_CMD_NAV_TAKEOFF,
                             true, // show error
@@ -939,6 +945,11 @@ void APMFirmwarePlugin::startMission(Vehicle* vehicle)
             return;
         }
     } else {
+        // Wait 300 msecs before sending a start mission command
+        for (int i=0; i<3; i++) {
+            QGC::SLEEP::msleep(100);
+            qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+        }
         vehicle->sendMavCommand(vehicle->defaultComponentId(), MAV_CMD_MISSION_START, true /*show error */);
     }
 }

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -950,8 +950,19 @@ void APMFirmwarePlugin::startMission(Vehicle* vehicle)
             return;
         }
     } else {
-        // Wait 300 msecs before sending a start mission command
-        for (int i=0; i<3; i++) {
+        // Wait 500 msecs after arming before switching to AUTO
+        for (int i=0; i<5; i++) {
+            QGC::SLEEP::msleep(100);
+            qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+        }
+
+        if (!_setFlightModeAndValidate(vehicle, "Auto")) {
+            qgcApp()->showAppMessage(tr("Unable to start mission: Vehicle failed to change to Auto mode."));
+            return;
+        }
+
+        // Wait 500 msecs before sending a start mission command
+        for (int i=0; i<5; i++) {
             QGC::SLEEP::msleep(100);
             qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
         }

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -918,8 +918,8 @@ bool FirmwarePlugin::_armVehicleAndValidate(Vehicle* vehicle)
     // Only try arming the vehicle a single time. Doing retries on arming with a delay can lead to safety issues.
     vehicle->setArmed(true, false /* showError */);
 
-    // Wait 1000 msecs for vehicle to arm
-    for (int i=0; i<10; i++) {
+    // Wait 2000 msecs for vehicle to arm
+    for (int i=0; i<20; i++) {
         if (vehicle->armed()) {
             vehicleArmed = true;
             break;

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -407,7 +407,7 @@ VisualMissionItem* MissionController::insertPayloadDropItems(int visualItemIndex
     SimpleMissionItem* release = qobject_cast<SimpleMissionItem*>(_insertSimpleMissionItemWorker(QGeoCoordinate(), MAV_CMD_DO_GRIPPER, visualItemIndex++, makeCurrentItem));
     release->missionItem().setParam2(0);
     SimpleMissionItem* delay = qobject_cast<SimpleMissionItem*>(_insertSimpleMissionItemWorker(QGeoCoordinate(), MAV_CMD_NAV_DELAY, visualItemIndex++, makeCurrentItem));
-    delay->missionItem().setParam1(1);
+    delay->missionItem().setParam1(2);
     SimpleMissionItem* grab = qobject_cast<SimpleMissionItem*>(_insertSimpleMissionItemWorker(QGeoCoordinate(), MAV_CMD_DO_GRIPPER, visualItemIndex, makeCurrentItem));
     grab->missionItem().setParam2(1);
     return grab;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -442,7 +442,7 @@ public:
     Q_INVOKABLE void actuateGripper(bool open);
 
     /// Open + delay + close gripper operation
-    Q_INVOKABLE void gripperOpenDelayClose(double delay_s = 1.0);
+    Q_INVOKABLE void gripperOpenDelayClose(double delay_s = 2.0);
     Q_PROPERTY(bool gripperActionExecuting READ gripperActionExecuting NOTIFY gripperActionExecutingChanged)
     bool gripperActionExecuting() { return _gripperExecuting; };
 


### PR DESCRIPTION
[MQ-18]

This PR introduces additional functionality to the takeoff and start mission actions to better match the actions Mission Planner executes. Specifically:

**Takeoff**
1. It arms in stabilize
2. Waits up to 2s for arming to complete
3. Switches to GUIDED
4. Waits 300ms (like Mission Planner) before sending a takeoff command

**Start mission**
1. It arms in stabilize
2. Waits up to 2s for arming to complete
3. Waits an additional 500ms before switching to AUTO
5. Waits 500ms (like Mission Planner) before sending a start mission command

Additionally, per Malloy's request I've modify the open/delay/close action for the gripper to wait 2s instead of 1s.

[MQ-18]: https://planckaero.atlassian.net/browse/MQ-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ