### PR TITLE
[MQ-12] Battery Percent Remaining Estimate

### DIFF
--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -526,7 +526,6 @@ SetupPage {
 
                 QGCLabel {
                     Layout.columnSpan:  3
-                    Layout.fillWidth:   true
                     font.pointSize:     ScreenTools.smallFontPointSize
                     wrapMode:           Text.WordWrap
                     text:               qsTr("If the vehicle reports a high current read when there is little or no current going through it, adjust the Amps Offset. It should be equal to the voltage reported by the sensor when the current is zero.")
@@ -534,8 +533,24 @@ SetupPage {
                 }
 
                 QGCLabel {
-                    text:       qsTr("Voltage Sag:")
-                    visible:    _showAdvanced
+                    text:             qsTr("Battery Percent Estimate:")
+                    visible:          _showAdvanced
+                }
+
+                QGCCheckBox {
+                    Layout.columnSpan:  2
+                    id:               _battEstCheckBox
+                    checked:          controller.vehicle.battEstEnabled
+                    text:             (checked) ? "Enabled" : "Disabled"
+
+                    onClicked: {
+                        controller.vehicle.battEstEnabled = checked
+                    }
+                }
+
+                QGCLabel {
+                    text:             qsTr("Voltage Sag:")
+                    visible:          _showAdvanced && _battEstCheckBox.checked
                 }
 
                 QGCTextField {
@@ -543,6 +558,9 @@ SetupPage {
                     width:            _fieldWidth
                     text:             controller.vehicle.voltageSag
                     inputMethodHints: Qt.ImhFormattedNumbersOnly
+                    unitsLabel:       "V"
+                    showUnits:        true
+                    visible:          _showAdvanced && _battEstCheckBox.checked
 
                     function setVoltageSag() {
                         let userInput = parseFloat(this.text)

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -533,6 +533,30 @@ SetupPage {
                     visible:            _showAdvanced
                 }
 
+                QGCLabel {
+                    text:       qsTr("Voltage Sag:")
+                    visible:    _showAdvanced
+                }
+
+                QGCTextField {
+                    id:               voltageSagField
+                    width:            _fieldWidth
+                    text:             controller.vehicle.voltageSag
+                    inputMethodHints: Qt.ImhFormattedNumbersOnly
+
+                    function setVoltageSag() {
+                        let userInput = parseFloat(this.text)
+                        if(userInput < 0 || userInput > 1000) {
+                            voltageSagField.text = controller.vehicle.voltageSag
+                        }
+                        else {
+                            controller.vehicle.voltageSag = userInput
+                        }
+                        console.info(controller.vehicle.voltageSag)
+                    }
+                    onEditingFinished: setVoltageSag()
+                }
+
             } // GridLayout
         } // Column
     } // Component - powerSetupComponent

--- a/src/Vehicle/BatteryFact.json
+++ b/src/Vehicle/BatteryFact.json
@@ -85,6 +85,13 @@
     "enumStrings":      "n/a,Ok,Low,Critical,Emergency,Failed,Unhealthy,Charging",
     "enumValues":       "0,1,2,3,4,5,6,7",
     "decimalPlaces":    0
+},
+{
+    "name":             "voltageBeforeTakeoff",
+    "shortDesc":        "Voltage Before Takeoff",
+    "type":             "double",
+    "decimalPlaces":    2,
+    "units":            "v"
 }
 ]
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2703,11 +2703,13 @@ bool Vehicle::guidedMode() const
 void Vehicle::setBattEstState(bool state)
 {
     _battEstEnabled = state;
+    emit battEstEnabledChanged();
 }
 
 void Vehicle::setVoltageSag(qreal v)
 {
     _voltageSag = v;
+    emit voltageSagChanged();
 }
 
 void Vehicle::setGuidedMode(bool guidedMode)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2700,6 +2700,11 @@ bool Vehicle::guidedMode() const
     return _firmwarePlugin->isGuidedMode(this);
 }
 
+void Vehicle::setBattEstState(bool state)
+{
+    _battEstEnabled = state;
+}
+
 void Vehicle::setVoltageSag(qreal v)
 {
     _voltageSag = v;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2700,6 +2700,11 @@ bool Vehicle::guidedMode() const
     return _firmwarePlugin->isGuidedMode(this);
 }
 
+void Vehicle::setVoltageSag(qreal v)
+{
+    _voltageSag = v;
+}
+
 void Vehicle::setGuidedMode(bool guidedMode)
 {
     return _firmwarePlugin->setGuidedMode(this, guidedMode);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -256,6 +256,7 @@ public:
     Q_PROPERTY(bool                 requiresGpsFix              READ requiresGpsFix                                                 NOTIFY requiresGpsFixChanged)
     Q_PROPERTY(double               loadProgress                READ loadProgress                                                   NOTIFY loadProgressChanged)
     Q_PROPERTY(bool                 initialConnectComplete      READ isInitialConnectComplete                                       NOTIFY initialConnectComplete)
+    Q_PROPERTY(bool                 battEstEnabled              READ battEstEnabled             WRITE setBattEstState               NOTIFY battEstEnabledChanged)
     Q_PROPERTY(qreal                voltageSag                  READ voltageSag                 WRITE setVoltageSag                 NOTIFY voltageSagChanged)
 
     // The following properties relate to Orbit status
@@ -518,6 +519,7 @@ public:
     bool supportsMotorInterference      () const;
     bool supportsTerrainFrame           () const;
 
+    void setBattEstState(bool state);
     void setVoltageSag(qreal v);
     void setGuidedMode(bool guidedMode);
 
@@ -835,6 +837,7 @@ public:
     qreal       gimbalYaw               () const{ return static_cast<qreal>(_curGimbalYaw); }
     bool        gimbalData              () const{ return _haveGimbalData; }
     bool        isROIEnabled            () const{ return _isROIEnabled; }
+    bool        battEstEnabled          () const{ return _battEstEnabled; }
     qreal       voltageSag              () const{ return _voltageSag; }
 
     CheckList   checkListState          () { return _checkListState; }
@@ -954,6 +957,7 @@ signals:
     void gimbalDataChanged              ();
     void isROIEnabledChanged            ();
     void initialConnectComplete         ();
+    void battEstEnabledChanged          ();
     void voltageSagChanged              ();
 
     void sensorsParametersResetAck      (bool success);
@@ -1184,6 +1188,7 @@ private:
     bool                _haveGimbalData = false;
     bool                _isROIEnabled   = false;
     Joystick*           _activeJoystick = nullptr;
+    bool                _battEstEnabled = false;
     qreal               _voltageSag     = 0.0f;
 
     bool _checkLatestStableFWDone = false;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -256,6 +256,7 @@ public:
     Q_PROPERTY(bool                 requiresGpsFix              READ requiresGpsFix                                                 NOTIFY requiresGpsFixChanged)
     Q_PROPERTY(double               loadProgress                READ loadProgress                                                   NOTIFY loadProgressChanged)
     Q_PROPERTY(bool                 initialConnectComplete      READ isInitialConnectComplete                                       NOTIFY initialConnectComplete)
+    Q_PROPERTY(qreal                voltageSag                  READ voltageSag                 WRITE setVoltageSag                 NOTIFY voltageSagChanged)
 
     // The following properties relate to Orbit status
     Q_PROPERTY(bool             orbitActive     READ orbitActive        NOTIFY orbitActiveChanged)
@@ -446,6 +447,7 @@ public:
     Q_PROPERTY(bool gripperActionExecuting READ gripperActionExecuting NOTIFY gripperActionExecutingChanged)
     bool gripperActionExecuting() { return _gripperExecuting; };
 
+    qreal   setVoltageSag           () const;
     bool    isInitialConnectComplete() const;
     bool    guidedModeSupported     () const;
     bool    pauseVehicleSupported   () const;
@@ -516,6 +518,7 @@ public:
     bool supportsMotorInterference      () const;
     bool supportsTerrainFrame           () const;
 
+    void setVoltageSag(qreal v);
     void setGuidedMode(bool guidedMode);
 
     QString prearmError() const { return _prearmError; }
@@ -832,6 +835,7 @@ public:
     qreal       gimbalYaw               () const{ return static_cast<qreal>(_curGimbalYaw); }
     bool        gimbalData              () const{ return _haveGimbalData; }
     bool        isROIEnabled            () const{ return _isROIEnabled; }
+    qreal       voltageSag              () const{ return _voltageSag; }
 
     CheckList   checkListState          () { return _checkListState; }
     void        setCheckListState       (CheckList cl)  { _checkListState = cl; emit checkListStateChanged(); }
@@ -950,6 +954,7 @@ signals:
     void gimbalDataChanged              ();
     void isROIEnabledChanged            ();
     void initialConnectComplete         ();
+    void voltageSagChanged              ();
 
     void sensorsParametersResetAck      (bool success);
 
@@ -1179,6 +1184,7 @@ private:
     bool                _haveGimbalData = false;
     bool                _isROIEnabled   = false;
     Joystick*           _activeJoystick = nullptr;
+    qreal               _voltageSag     = 0.0f;
 
     bool _checkLatestStableFWDone = false;
     int _firmwareMajorVersion = versionNotSetValue;

--- a/src/Vehicle/VehicleBatteryFactGroup.cc
+++ b/src/Vehicle/VehicleBatteryFactGroup.cc
@@ -25,6 +25,7 @@ const char* VehicleBatteryFactGroup::_instantPowerFactName          = "instantPo
 const char* VehicleBatteryFactGroup::_timeRemainingFactName         = "timeRemaining";
 const char* VehicleBatteryFactGroup::_timeRemainingStrFactName      = "timeRemainingStr";
 const char* VehicleBatteryFactGroup::_chargeStateFactName           = "chargeState";
+const char* VehicleBatteryFactGroup::_voltageBeforeTakeoffFactName  = "voltageBeforeTakeoff";
 
 const char* VehicleBatteryFactGroup::_settingsGroup =                       "Vehicle.battery";
 
@@ -42,6 +43,7 @@ VehicleBatteryFactGroup::VehicleBatteryFactGroup(uint8_t batteryId, QObject* par
     , _timeRemainingStrFact (0, _timeRemainingStrFactName,          FactMetaData::valueTypeString)
     , _chargeStateFact      (0, _chargeStateFactName,               FactMetaData::valueTypeUint8)
     , _instantPowerFact     (0, _instantPowerFactName,              FactMetaData::valueTypeDouble)
+    , _voltageBeforeTakeoffFact(0, _voltageFactName,                FactMetaData::valueTypeDouble)
 {
     _addFact(&_batteryIdFact,               _batteryIdFactName);
     _addFact(&_batteryFunctionFact,         _batteryFunctionFactName);
@@ -55,6 +57,7 @@ VehicleBatteryFactGroup::VehicleBatteryFactGroup(uint8_t batteryId, QObject* par
     _addFact(&_timeRemainingStrFact,        _timeRemainingStrFactName);
     _addFact(&_chargeStateFact,             _chargeStateFactName);
     _addFact(&_instantPowerFact,            _instantPowerFactName);
+    _addFact(&_voltageBeforeTakeoffFact,    _voltageBeforeTakeoffFactName);
 
     _batteryIdFact.setRawValue          (batteryId);
     _batteryFunctionFact.setRawValue    (MAV_BATTERY_FUNCTION_UNKNOWN);
@@ -67,6 +70,7 @@ VehicleBatteryFactGroup::VehicleBatteryFactGroup(uint8_t batteryId, QObject* par
     _timeRemainingFact.setRawValue      (qQNaN());
     _chargeStateFact.setRawValue        (MAV_BATTERY_CHARGE_STATE_UNDEFINED);
     _instantPowerFact.setRawValue       (qQNaN());
+    _voltageBeforeTakeoffFact.setRawValue(qQNaN());
 
     connect(&_timeRemainingFact, &Fact::rawValueChanged, this, &VehicleBatteryFactGroup::_timeRemainingChanged);
 }
@@ -160,6 +164,9 @@ void VehicleBatteryFactGroup::_handleBatteryStatus(Vehicle* vehicle, mavlink_mes
     group->timeRemaining()->setRawValue     (batteryStatus.time_remaining == 0 ?        qQNaN() : batteryStatus.time_remaining);
     group->chargeState()->setRawValue       (batteryStatus.charge_state);
     group->instantPower()->setRawValue      (totalVoltage * group->current()->rawValue().toDouble());
+    // Store voltage before takeoff value only when vehicle is disarmed
+    if (!vehicle->armed())
+        group->voltageBeforeTakeoff()->setRawValue(totalVoltage);
     group->_setTelemetryAvailable(true);
 }
 

--- a/src/Vehicle/VehicleBatteryFactGroup.h
+++ b/src/Vehicle/VehicleBatteryFactGroup.h
@@ -21,18 +21,19 @@ class VehicleBatteryFactGroup : public FactGroup
 public:
     VehicleBatteryFactGroup(uint8_t batteryId, QObject* parent = nullptr);
 
-    Q_PROPERTY(Fact* id                 READ id                 CONSTANT)
-    Q_PROPERTY(Fact* function           READ function           CONSTANT)
-    Q_PROPERTY(Fact* type               READ type               CONSTANT)
-    Q_PROPERTY(Fact* temperature        READ temperature        CONSTANT)
-    Q_PROPERTY(Fact* voltage            READ voltage            CONSTANT)
-    Q_PROPERTY(Fact* current            READ current            CONSTANT)
-    Q_PROPERTY(Fact* mahConsumed        READ mahConsumed        CONSTANT)
-    Q_PROPERTY(Fact* percentRemaining   READ percentRemaining   CONSTANT)
-    Q_PROPERTY(Fact* timeRemaining      READ timeRemaining      CONSTANT)
-    Q_PROPERTY(Fact* timeRemainingStr   READ timeRemainingStr   CONSTANT)
-    Q_PROPERTY(Fact* chargeState        READ chargeState        CONSTANT)
-    Q_PROPERTY(Fact* instantPower       READ instantPower       CONSTANT)
+    Q_PROPERTY(Fact* id                   READ id                   CONSTANT)
+    Q_PROPERTY(Fact* function             READ function             CONSTANT)
+    Q_PROPERTY(Fact* type                 READ type                 CONSTANT)
+    Q_PROPERTY(Fact* temperature          READ temperature          CONSTANT)
+    Q_PROPERTY(Fact* voltage              READ voltage              CONSTANT)
+    Q_PROPERTY(Fact* current              READ current              CONSTANT)
+    Q_PROPERTY(Fact* mahConsumed          READ mahConsumed          CONSTANT)
+    Q_PROPERTY(Fact* percentRemaining     READ percentRemaining     CONSTANT)
+    Q_PROPERTY(Fact* timeRemaining        READ timeRemaining        CONSTANT)
+    Q_PROPERTY(Fact* timeRemainingStr     READ timeRemainingStr     CONSTANT)
+    Q_PROPERTY(Fact* chargeState          READ chargeState          CONSTANT)
+    Q_PROPERTY(Fact* instantPower         READ instantPower         CONSTANT)
+    Q_PROPERTY(Fact* voltageBeforeTakeoff READ voltageBeforeTakeoff CONSTANT)
 
     Fact* id                        () { return &_batteryIdFact; }
     Fact* function                  () { return &_batteryFunctionFact; }
@@ -46,6 +47,7 @@ public:
     Fact* timeRemaining             () { return &_timeRemainingFact; }
     Fact* timeRemainingStr          () { return &_timeRemainingStrFact; }
     Fact* chargeState               () { return &_chargeStateFact; }
+    Fact* voltageBeforeTakeoff      () { return &_voltageBeforeTakeoffFact; }
 
     static const char* _batteryIdFactName;
     static const char* _batteryFunctionFactName;
@@ -59,6 +61,7 @@ public:
     static const char* _timeRemainingStrFactName;
     static const char* _chargeStateFactName;
     static const char* _instantPowerFactName;
+    static const char* _voltageBeforeTakeoffFactName;
 
     static const char* _settingsGroup;
 
@@ -89,6 +92,7 @@ private:
     Fact            _timeRemainingStrFact;
     Fact            _chargeStateFact;
     Fact            _instantPowerFact;
+    Fact            _voltageBeforeTakeoffFact;
 
     static const char* _batteryFactGroupNamePrefix;
 };

--- a/src/ui/toolbar/BatteryIndicator.qml
+++ b/src/ui/toolbar/BatteryIndicator.qml
@@ -29,6 +29,10 @@ Item {
 
     property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
 
+    // TODO: parameterize battery range
+    property real _battVoltMax:  (_activeVehicle.armed) ? 58.3 : 58.3-_activeVehicle.voltageSag
+    property real _battVoltMin:  (_activeVehicle.armed) ? 46.9 : 43.2
+
     Row {
         id:             batteryIndicatorRow
         anchors.top:    parent.top
@@ -84,7 +88,12 @@ Item {
                         return battery.percentRemaining.valueString + battery.percentRemaining.units
                     }
                 } else if (!isNaN(battery.voltage.rawValue)) {
-                    return battery.voltage.valueString + battery.voltage.units
+                    // Estimate percent remaining if voltage is roughly above the battery voltage minimum
+                    // TODO: should this be activated rather than on by default?
+                    let percentRemaining = (battery.voltage.rawValue-_battVoltMin)/(_battVoltMax-_battVoltMin)*100;
+                    return qsTr("%1\%").arg(percentRemaining)
+
+                    // return battery.voltage.valueString + battery.voltage.units
                 } else if (battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED) {
                     return battery.chargeState.enumStringValue
                 }

--- a/src/ui/toolbar/BatteryIndicator.qml
+++ b/src/ui/toolbar/BatteryIndicator.qml
@@ -90,14 +90,16 @@ Item {
                         return battery.percentRemaining.valueString + battery.percentRemaining.units
                     }
                 } else if (!isNaN(battery.voltage.rawValue)) {
-                    var percentRemaining = (battery.voltageBeforeTakeoff.rawValue-_battVoltMin)/(_battVoltMax-_battVoltMin)
-                    if (_activeVehicle.armed()) {
-                        percentRemaining *= (battery.voltage.rawValue-_battVoltMinUnderLoad)/(_battVoltMaxUnderLoad-_battVoltMinUnderLoad)
+                    // Calculate battery percent remaining estimate
+                    if (_activeVehicle.battEstEnabled) {
+                        var percentRemaining = (battery.voltageBeforeTakeoff.rawValue-_battVoltMin)/(_battVoltMax-_battVoltMin)
+                        if (_activeVehicle.armed) {
+                            percentRemaining *= (battery.voltage.rawValue-_battVoltMinUnderLoad)/(_battVoltMaxUnderLoad-_battVoltMinUnderLoad)
+                        }
+                        return qsTr("%1\%").arg(percentRemaining*100)
                     }
-                    // Estimate percent remaining if voltage is roughly above the battery voltage minimum
-                    return qsTr("%1\%").arg(percentRemaining*100)
 
-                    // return battery.voltage.valueString + battery.voltage.units
+                    return battery.voltage.valueString + battery.voltage.units
                 } else if (battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED) {
                     return battery.chargeState.enumStringValue
                 }


### PR DESCRIPTION
[MQ-12](https://planckaero.atlassian.net/browse/MQ-12)

Add ability to enable battery percent remaining estimate and set voltage sag amount in the Power component UI. If enabled, the battery display changes to a percentage using the voltage sag entered.

**NOTE: Voltage ranges nominally and under load are hard coded in `BatteryIndicator.qml`**

![image](https://user-images.githubusercontent.com/3850326/171906848-8016da2b-2c2a-4cf3-8258-81f9fc6c3f7c.png)
